### PR TITLE
Update/compare mode/doc

### DIFF
--- a/API.md
+++ b/API.md
@@ -352,7 +352,7 @@ In this example, differencify will got to different pages and compare screenshot
       cache.prev = context.image;
     })
     .goto('https://www.google.com')
-    .toMatchSnapshot(cache.prev)
+    .toMatchSnapshot(() => cache.prev)
     .result((result) => {
       console.log(result); // True or False
     })

--- a/API.md
+++ b/API.md
@@ -342,19 +342,17 @@ In this example, differencify will got to different pages and compare screenshot
 
 ```js
 (async () => {
-  let cache = {};
+  const cache = {};
   await differencify
     .init()
     .newPage()
-    .goto('https://www.google.co.uk')
+    .goto('https://www.bing.com')
     .screenshot()
-    .then(img => {
-      cache['uk'] = img;
-      return img;
+    .introspect((context) => {
+      cache.prev = context.image;
     })
-    .goto('https://www.google.com.au')
-    .screenshot()
-    .toMatchSnapshot(cache['uk'])
+    .goto('https://www.google.com')
+    .toMatchSnapshot(cache.prev)
     .result((result) => {
       console.log(result); // True or False
     })

--- a/API.md
+++ b/API.md
@@ -338,6 +338,46 @@ In this example, differencify will got to different pages and compare screenshot
 ```
 In this example, differencify will got to different pages and compare screenshots with reference screenshots.
 
+## Compare different pages using cache
 
+```js
+(async () => {
+  await differencify
+    .init()
+    .newPage()
+    .goto('https://www.google.co.uk')
+    .screenshot({toCache: 'UK'})
+    .goto('https://www.google.com.au')
+    .screenshot()
+    .toMatchSnapshot({fromCache: 'AU'})
+    .result((result) => {
+      console.log(result); // True or False
+    })
+    .close()
+    .end();
+})();
+```
+In this example, differencify will go to one page and cache the screenshot, then go to srcreenshot and compare a new page to the previous cached copy. No reference snapshot persists.
+
+## Compare different pages using cache when unchained
+
+```js
+(async () => {
+  const target = differencify.init({ chain: false });
+  const page = await target.newPage();
+  await page.goto('https://www.google.co.uk');
+  await page.setViewport({ width: 1600, height: 1200 });
+  await page.waitFor(1000);
+  await page.screenshot({toCache: 'UK');
+  await page.goto('https://www.google.com.au');
+  await page.setViewport({ width: 1600, height: 1200 });
+  await page.waitFor(1000);
+  const image = await page.screenshot();
+  const result = await target.toMatchSnapshot(image, {fromCache: 'UK'});
+  await page.close();
+  console.log(result); // True or False
+})();
+```
+In this example, differencify will go to one page and cache the screenshot, then go to srcreenshot and compare a new page to the previous cached copy. No reference snapshot persists.
 
 

--- a/API.md
+++ b/API.md
@@ -354,7 +354,7 @@ In this example, differencify will got to different pages and compare screenshot
     .goto('https://www.google.com')
     // In chained, a and b must be functions, else throw error
     // a defaults to target.image
-    .toCompare({b: () => cache.prev}) 
+    .compareImages({b: () => cache.prev}) 
     .result((result) => {
       console.log(result); // True or False
     })
@@ -378,7 +378,7 @@ In this example, differencify will go to one page and cache the screenshot, then
   await page.setViewport({ width: 1600, height: 1200 });
   await page.waitFor(1000);
   const image = await page.screenshot();
-  const result = await target.toCompare({a: image, b: imageCached});
+  const result = await target.compareImages({a: image, b: imageCached});
   await page.close();
   console.log(result); // True or False
 })();

--- a/API.md
+++ b/API.md
@@ -342,14 +342,19 @@ In this example, differencify will got to different pages and compare screenshot
 
 ```js
 (async () => {
+  let cache = {};
   await differencify
     .init()
     .newPage()
     .goto('https://www.google.co.uk')
-    .screenshot({toCache: 'UK'})
+    .screenshot()
+    .then(img => {
+      cache['uk'] = img;
+      return img;
+    })
     .goto('https://www.google.com.au')
     .screenshot()
-    .toMatchSnapshot({fromCache: 'AU'})
+    .toMatchSnapshot(cache['uk'])
     .result((result) => {
       console.log(result); // True or False
     })
@@ -368,12 +373,12 @@ In this example, differencify will go to one page and cache the screenshot, then
   await page.goto('https://www.google.co.uk');
   await page.setViewport({ width: 1600, height: 1200 });
   await page.waitFor(1000);
-  await page.screenshot({toCache: 'UK');
+  const imageCached = await page.screenshot();
   await page.goto('https://www.google.com.au');
   await page.setViewport({ width: 1600, height: 1200 });
   await page.waitFor(1000);
   const image = await page.screenshot();
-  const result = await target.toMatchSnapshot(image, {fromCache: 'UK'});
+  const result = await target.toMatchSnapshot(image, imageCached);
   await page.close();
   console.log(result); // True or False
 })();

--- a/API.md
+++ b/API.md
@@ -342,19 +342,19 @@ In this example, differencify will got to different pages and compare screenshot
 
 ```js
 (async () => {
-  const cache = {};
+  const cachedImage;
   await differencify
     .init()
     .newPage()
     .goto('https://www.bing.com')
     .screenshot()
     .introspect((context) => {
-      cache.prev = context.image;
+      cachedImage = context.image;
     })
     .goto('https://www.google.com')
-    // In chained, a and b must be functions, else throw error
-    // a defaults to target.image
-    .compareImages({b: () => cache.prev}) 
+    // In chained, "a" and "b" must be functions that return Buffers, else an error is thrown
+    // "a" defaults to target.image
+    .compareImages({b: () => cachedImage}) 
     .result((result) => {
       console.log(result); // True or False
     })

--- a/API.md
+++ b/API.md
@@ -352,7 +352,9 @@ In this example, differencify will got to different pages and compare screenshot
       cache.prev = context.image;
     })
     .goto('https://www.google.com')
-    .toMatchSnapshot(() => cache.prev)
+    // In chained, a and b must be functions, else throw error
+    // a defaults to target.image
+    .toCompare({b: () => cache.prev}) 
     .result((result) => {
       console.log(result); // True or False
     })
@@ -376,7 +378,7 @@ In this example, differencify will go to one page and cache the screenshot, then
   await page.setViewport({ width: 1600, height: 1200 });
   await page.waitFor(1000);
   const image = await page.screenshot();
-  const result = await target.toMatchSnapshot(image, imageCached);
+  const result = await target.toCompare({a: image, b: imageCached});
   await page.close();
   console.log(result); // True or False
 })();


### PR DESCRIPTION
# Compare pages API

 📖  📖  **docs only** 📖  📖 , implementation to follow

## Background

* [Github Issue](https://github.com/NimaSoroush/differencify/issues/65)


## Work done

I have a proof of concept working on my local machine, so now I'm thinking about a good API.

### _Attempt 1 ([commit](https://github.com/AshCoolman/differencify/commit/9435436f3c324df10c1dc5c4acee0d5673bcd0fc))_
Uses config objects and introduces an internal cache object to keep store image data for later comparisons. This roughly matches the different parameter usage that `toMatchSnapshot` has when chained vs unchained.

### _Attempt 2 (current state)_
I then decided against adding internal state. If that is done for every new feature, the lib might not scale so well? I though perhaps better to expose (the edges of) the internals, and give people the power.

So, I propose:

1. exposing the internal state via "`introspect`". It takes a function which it calls with a proxy (lowercase "p") object with certain exposed state - aka [a big bag of variables](https://github.com/jaredpalmer/formik#the-formikbag).
2. adding a `compareImages` function, with a config object

### _Alternative_
If you don't like these two, initially I was passing in the spec, and using that to access the appropriate snapshot to compare against.

```
var spec = it('test', () => await.browser.goto(LIVE).screenshot().toMatchSnapshot())
it('live', () => await.browser.goto(LIVE).screenshot().toMatchSnapshot().compareWithSpec(spec)
```

## Notes

Due to the async control-flow of the chained API, the cached image that is passed to `.compareImages` needs to be accessed dynamically. 